### PR TITLE
fix(FEV-1392): use timeline marker width and height if doesn't exist on preview object

### DIFF
--- a/src/components/cue-point/cue-point.js
+++ b/src/components/cue-point/cue-point.js
@@ -198,8 +198,8 @@ class CuePoint extends preact.Component {
     };
     markerProps = {...marker.props, ...markerProps};
 
-    const previewWidth = preview.width || style.framePreviewImgWidth;
-    const previewHeight = preview.height || style.framePreviewImgHeight;
+    const previewWidth = preview.width || marker.width;
+    const previewHeight = preview.height || marker.height;
     const previewStyle = {
       width: `${previewWidth}px`,
       height: `${previewHeight}px`


### PR DESCRIPTION


### Description of the Changes

Please add a detailed description of the change, weather it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
