### PR TITLE
fix(FEC-13331): handle seekbar a11y when timeline preview is focused

### DIFF
--- a/src/components/marker/timeline-preview.tsx
+++ b/src/components/marker/timeline-preview.tsx
@@ -275,6 +275,22 @@ export class TimelinePreview extends Component<TimelinePreviewProps> {
     return null;
   }
 
+  handleFocus = () => {
+    const seekBarNode = this.props.getSeekBarNode();
+    if (seekBarNode) {
+      // change slider role to prevent interrupts reading marker content by screen-readers
+      seekBarNode.setAttribute('role', 'none');
+    }
+  };
+
+  handleBlur = () => {
+    const seekBarNode = this.props.getSeekBarNode();
+    if (seekBarNode) {
+      // restore slider role
+      seekBarNode.setAttribute('role', 'slider');
+    }
+  };
+
   render() {
     if (this.props.hidePreview) {
       return null;
@@ -293,7 +309,14 @@ export class TimelinePreview extends Component<TimelinePreviewProps> {
         onMouseLeave={() => this.onMouseLeave(relevantChapter)}>
         {this._shouldRenderHeader(relevantChapter) ? (
           <A11yWrapper onClick={this.onPreviewHeaderClick}>
-            <div className={styles.header} ref={node => this._previewHeaderElement = node} data-testid="cuePointPreviewHeader" style={previewHeaderStyle} tabIndex={0}>
+            <div
+              className={styles.header}
+              ref={node => this._previewHeaderElement = node}
+              data-testid="cuePointPreviewHeader"
+              style={previewHeaderStyle}
+              tabIndex={0}
+              onFocus={this.handleFocus}
+              onBlur={this.handleBlur}>
               <div className={styles.itemsWrapper} data-testid="cuePointPreviewHeaderItems">
                 {this._renderHeader(relevantChapter, data)}
               </div>


### PR DESCRIPTION
### Description of the Changes

**the issue:**
when voiceOver is enabled and focusing on a timeline preview header title, the voiceover also focuses on the seekbar element.

**fix:**
change the role of the seekbar element from `slider` to `none` and vice-versa on `focus` and `blur` of `timelinePreview` component.

Solves [FEC-13331](https://kaltura.atlassian.net/browse/FEC-13331)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[FEC-13331]: https://kaltura.atlassian.net/browse/FEC-13331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ