### PR TITLE
fix(FEC-13337): preview title with too many characters is not shown properly

### DIFF
--- a/src/components/marker/timeline-preview.scss
+++ b/src/components/marker/timeline-preview.scss
@@ -58,6 +58,7 @@
           white-space: nowrap;
           overflow: hidden;
           text-overflow: ellipsis;
+          max-width: 320px;
         }
       }
     }


### PR DESCRIPTION
### Description of the Changes

add `max-width: 320px` to the preview title element per design.

Solves [FEC-13337](https://kaltura.atlassian.net/browse/FEC-13337)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[FEC-13337]: https://kaltura.atlassian.net/browse/FEC-13337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ