### PR TITLE
fix(FEC-13337): fix hover width on title preview

### DIFF
--- a/src/components/marker/timeline-preview.scss
+++ b/src/components/marker/timeline-preview.scss
@@ -40,7 +40,6 @@
     margin-bottom: 2px;
     position: absolute;
     top: 10px;
-    max-width: 320px;
     .items-wrapper {
       display: flex;
       flex-direction: row;


### PR DESCRIPTION
### Description of the Changes

remove `max-width` for header element- it causes the hover to be shorter than the text.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
