### PR TITLE
feat(FEC-13017): add dua-screen thumbnails on the timeline

### DIFF
--- a/src/components/chapters/seekbar-segment.js
+++ b/src/components/chapters/seekbar-segment.js
@@ -159,7 +159,7 @@ class SeekBarSegment extends Component {
    * @memberof SeekBarSegment
    */
   render(props: any): React$Element<any> {
-    const {virtualTime, currentTime, isDraggingActive, isHovered, isDummy} = props;
+    const {virtualTime, currentTime, isDraggingActive, isHovered} = props;
     this._wasDragging = isDraggingActive !== this._prevDraggingState;
     this._prevDraggingState = isDraggingActive;
     const progressWidth = `${this._getProgressWidth(isDraggingActive || this._wasDragging ? virtualTime : currentTime)}%`;
@@ -169,7 +169,9 @@ class SeekBarSegment extends Component {
     const segmentBufferedWidth = Math.round(this._getSegmentBufferedWidth(segmentWidth, totalBufferedWidth));
 
     const segmentStyleClass = [styles.seekBarSegment];
-    if (isHovered) segmentStyleClass.push(styles.hover);
+    if (isHovered) {
+      segmentStyleClass.push(styles.hovered);
+    }
 
     return (
       <div
@@ -178,7 +180,6 @@ class SeekBarSegment extends Component {
         className={segmentStyleClass.join(' ')}
         style={`width: ${segmentWidth}px;`}
         ref={node => (this._segmentEl = node)}>
-        <div className={[styles.segmentPadding, isDummy ? styles.dummy : ''].join(' ')} />
         <div className={styles.buffered} style={{width: `${segmentBufferedWidth}%`}} />
         {props.dataLoaded ? <div className={styles.segmentProgress} style={{width: progressWidth}} /> : undefined}
       </div>

--- a/src/components/chapters/seekbar-segment.scss
+++ b/src/components/chapters/seekbar-segment.scss
@@ -1,43 +1,33 @@
 @import '../../theme';
 
+@mixin base-segment {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  border-radius: inherit;
+}
+
 .seek-bar-segment {
-  background-color: rgba(255,255,255,.3);
+  background-color: rgba(255, 255, 255, 0.3);
   height: $progress-bar-height;
   transition: height 200ms ease, transform 200ms ease;
   position: relative;
   transform: translateY(0);
 
-  .segment-padding {
-    position: absolute;
-    width: 100%;
-    height: 20px;
-    bottom: -7px;
-  }
-
-  &:hover, &.hover {
+  &:hover,
+  &.hovered {
     height: 2 * $progress-bar-height;
     transform: translateY(calc($progress-bar-height / -2));
-    .segment-padding:not(.dummy) {
-      height: 30px;
-      bottom: -8px;
-    }
   }
 
   .segment-progress {
-    position: absolute;
-    top: 0;
-    left: 0;
-    height: 100%;
-    border-radius: inherit;
+    @include base-segment;
     background-color: $primary-color;
   }
 
   .buffered {
-    position: absolute;
-    top: 0;
-    left: 0;
-    height: 100%;
-    border-radius: inherit;
+    @include base-segment;
     background-color: rgba(255, 255, 255, 0.3);
   }
 }

--- a/src/components/chapters/segments-wrapper.js
+++ b/src/components/chapters/segments-wrapper.js
@@ -86,7 +86,6 @@ class SegmentsWrapper extends Component {
               title={chapter.title}
               isHovered={chapter.isHovered}
               isDummy={chapter.isDummy}
-              getThumbnailInfo={props.getThumbnailInfo}
             />
           );
         })}

--- a/src/components/cue-point/cue-point.js
+++ b/src/components/cue-point/cue-point.js
@@ -34,6 +34,7 @@ const SEGMENT_GAP = 2;
 @redux.connect(mapStateToProps, utils.bindActions(reducers.seekbar.actions))
 class CuePoint extends preact.Component {
   _markerRef: ?HTMLDivElement;
+  _previewRef: ?HTMLDivElement;
   _hideTimeBubble: boolean;
 
   /**
@@ -80,16 +81,17 @@ class CuePoint extends preact.Component {
   _getPreviewPosition(previewWidth: number): number {
     let left = 0;
     if (this._markerRef) {
+      const previewWrapperWidth = this._previewRef?.getBoundingClientRect()?.width ?? previewWidth;
       const markerRect = this._markerRef.getBoundingClientRect();
       const seekbarRect = this.props.seekbarClientRect;
       const markerLeft = markerRect.left - seekbarRect.left;
       const markerWidth = markerRect.width;
       const markerRight = markerLeft + markerWidth;
       const seekbarWidth = seekbarRect.width;
-      const previewOffset = (previewWidth - markerWidth) / 2;
+      const previewOffset = (previewWrapperWidth - markerWidth) / 2;
       if (markerLeft - previewOffset > 0) {
         if (markerRight + previewOffset > seekbarWidth) {
-          left = -(previewWidth - (seekbarWidth - markerLeft));
+          left = -(previewWrapperWidth - (seekbarWidth - markerLeft));
         } else {
           left = -previewOffset;
         }
@@ -173,6 +175,15 @@ class CuePoint extends preact.Component {
 
   /**
    *
+   * @returns {void}
+   * @private
+   */
+  _update = () => {
+    this.setState(prevState => ({render: !prevState.render}));
+  };
+
+  /**
+   *
    * @param {HTMLDivElement} ref - ref
    * @returns {void}
    * @private
@@ -180,7 +191,20 @@ class CuePoint extends preact.Component {
   _setMarkerRef = (ref: HTMLDivElement | null) => {
     if (ref) {
       this._markerRef = ref;
-      this.setState(prevState => ({render: !prevState.render}));
+      this._update();
+    }
+  };
+
+  /**
+   *
+   * @param {HTMLDivElement} ref - ref
+   * @returns {void}
+   * @private
+   */
+  _setPreviewRef = (ref: HTMLDivElement | null) => {
+    if (ref) {
+      this._previewRef = ref;
+      this._update();
     }
   };
 
@@ -193,7 +217,9 @@ class CuePoint extends preact.Component {
     const {marker, preview, virtualTime, config, hoverActive} = props;
     const {edge, left} = this._getMarkerPositionStyle();
 
-    const cuePointContainerStyle = {left};
+    const cuePointContainerStyle = {
+      left
+    };
     if (edge !== 'none') {
       cuePointContainerStyle[`padding${edge}`] = 0;
     }
@@ -259,7 +285,8 @@ class CuePoint extends preact.Component {
             ].join(' ')}
             style={{
               left: `${this._getPreviewPosition(previewWidth)}px`
-            }}>
+            }}
+            ref={this._setPreviewRef}>
             {preact.h(preview.get, previewProps)}
           </div>
         ) : undefined}

--- a/src/components/marker/timeline-marker.scss
+++ b/src/components/marker/timeline-marker.scss
@@ -1,5 +1,13 @@
 @import '../../theme.scss';
 
+$transition: height 200ms ease, transform 200ms ease;
+@mixin marker {
+  width: 4px;
+  height: 100%;
+  background-color: #ffffff;
+  border-radius: 2px;
+}
+
 .quizQuestionMarkerSize {
   display: flex;
   justify-content: center;
@@ -10,13 +18,10 @@
   outline-offset: 1px;
   &.hover {
     height: 12px;
-    transition: height 200ms ease, transform 200ms ease;
+    transition: $transition;
   }
   .marker {
-    width: 4px;
-    height: 100%;
-    border-radius: 2px;
-    background-color: #ffffff;
+    @include marker;
   }
 }
 
@@ -29,13 +34,10 @@
   outline-offset: 1px;
   &.hover {
     height: 8px;
-    transition: height 200ms ease, transform 200ms ease;
+    transition: $transition;
     border-radius: 2px;
   }
   .marker {
-    width: 4px;
-    height: 100%;
-    background-color: #ffffff;
-    border-radius: 2px;
+    @include marker;
   }
 }

--- a/src/components/marker/timeline-preview.scss
+++ b/src/components/marker/timeline-preview.scss
@@ -6,6 +6,7 @@
   cursor: pointer;
   position: relative;
   padding-top: 40px;
+  z-index: 1;
   &:not(.xs-player) {
     .header:hover {
       background: rgba(0, 0, 0, 0.6);
@@ -29,6 +30,15 @@
         margin-right: 4px;
       }
     }
+  }
+  &::after {
+    position: absolute;
+    bottom: -14px;
+    content: "";
+    width: 100%;
+    height: 14px;
+    display: block;
+    background-color: transparent;
   }
   .header {
     display: flex;
@@ -64,6 +74,7 @@
     }
   }
   .image-container {
+    display: flex;
     background: rgba(0, 0, 0, 0.7);
     background-clip: content-box;
     border: 2px solid rgba(255, 255, 255, 0.2);

--- a/src/types/timelineTypes.ts
+++ b/src/types/timelineTypes.ts
@@ -14,6 +14,7 @@ export interface ThumbnailInfo {
   width: number;
   x: number;
   y: number;
+  slide?: boolean;
 }
 
 export interface TimelineMarkerProps {


### PR DESCRIPTION
### Description of the Changes

solves: https://kaltura.atlassian.net/browse/FEC-13017

In case of dual-screen plugin exist - replace default preview component to custom one that uses thumb-preview API of dual-screen plugin
Related PR: https://github.com/kaltura/playkit-js-dual-screen/pull/117

<img width="452" alt="image" src="https://github.com/kaltura/playkit-js-timeline/assets/51074448/42e018c8-06a6-4ab8-bc46-fb38c9a3b499">


### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
