### PR TITLE
fix(FEC-13424): timeline segments issue with playlist

### DIFF
--- a/cypress/e2e/timeline.cy.ts
+++ b/cypress/e2e/timeline.cy.ts
@@ -227,6 +227,7 @@ describe('Timeline plugin', () => {
       mockKalturaBe();
       loadPlayer().then(player => {
         const timelineService = player.getService('timeline');
+        cy.stub(timelineService, '_isDurationCorrect', () => true);
         timelineService.addKalturaCuePoint(10, 'Hotspot', '1');
         cy.get('[data-testid="cuePointContainer"]').should('exist');
         cy.wait(1000);
@@ -248,6 +249,7 @@ describe('Timeline plugin', () => {
       mockKalturaBe();
       loadPlayer().then(player => {
         const timelineService = player.getService('timeline');
+        cy.stub(timelineService, '_isDurationCorrect', () => true);
         timelineService.addKalturaCuePoint(0, 'Chapter', '1', 'Chapter 1');
         timelineService.addKalturaCuePoint(18, 'Chapter', '2', 'Chapter 2');
         cy.get('[data-testid="segmentsWrapper"]').should('exist');
@@ -259,6 +261,7 @@ describe('Timeline plugin', () => {
       mockKalturaBe();
       loadPlayer().then(player => {
         const timelineService = player.getService('timeline');
+        cy.stub(timelineService, '_isDurationCorrect', () => true);
         timelineService.addKalturaCuePoint(10, 'Chapter', '1', 'Chapter 1');
         timelineService.addKalturaCuePoint(18, 'Chapter', '2', 'Chapter 2');
         cy.get('[data-testid="segmentsWrapper"]').should('exist');
@@ -270,6 +273,7 @@ describe('Timeline plugin', () => {
       mockKalturaBe();
       loadPlayer().then(player => {
         const timelineService = player.getService('timeline');
+        cy.stub(timelineService, '_isDurationCorrect', () => true);
         timelineService.addKalturaCuePoint(10, 'Chapter', '1', 'Chapter 1');
         timelineService.addKalturaCuePoint(18, 'Chapter', '2', 'Chapter 2');
         cy.get('[data-testid="segmentsWrapper"]').should('exist');
@@ -295,6 +299,7 @@ describe('Timeline plugin', () => {
       mockKalturaBe();
       loadPlayer().then(player => {
         const timelineService = player.getService('timeline');
+        cy.stub(timelineService, '_isDurationCorrect', () => true);
         timelineService.addKalturaCuePoint(0, 'Chapter', '1', 'Chapter 1');
         timelineService.addKalturaCuePoint(18, 'Chapter', '2', 'Chapter 2');
         cy.get('[data-testid="segmentsWrapper"]').should('exist');
@@ -346,6 +351,7 @@ describe('Timeline plugin', () => {
         };
         player.registerService('dualScreen', fakeDualScreenPlugin);
         const timelineService = player.getService('timeline');
+        cy.stub(timelineService, '_isDurationCorrect', () => true);
         timelineService.addKalturaCuePoint(10, 'Chapter', '1', 'Chapter 1');
         cy.get('[data-testid="cuePointPreviewImageContainer"]').children().should('have.length', 1);
       });
@@ -358,6 +364,7 @@ describe('Timeline plugin', () => {
         };
         player.registerService('dualScreen', fakeDualScreenPlugin);
         const timelineService = player.getService('timeline');
+        cy.stub(timelineService, '_isDurationCorrect', () => true);
         timelineService.addKalturaCuePoint(10, 'Chapter', '1', 'Chapter 1');
         cy.get('[data-testid="cuePointPreviewImageContainer"]').children().should('have.length', 2);
       });

--- a/src/components/chapters/segments-wrapper.js
+++ b/src/components/chapters/segments-wrapper.js
@@ -55,7 +55,7 @@ class SegmentsWrapper extends Component {
   componentWillUpdate(): void {
     if (!this._lastSegmentUpdated) {
       const potentialLastSegment = this.props.segments[this.props.segments.length - 1];
-      if (potentialLastSegment.endTime - this.props.duration < 1) {
+      if (potentialLastSegment.endTime <= this.props.duration && this.props.duration - potentialLastSegment.endTime < 1) {
         this.props.updateSegmentEndTime(potentialLastSegment.id, this.props.duration);
         this._lastSegmentUpdated = true;
       }

--- a/src/components/chapters/segments-wrapper.js
+++ b/src/components/chapters/segments-wrapper.js
@@ -1,6 +1,6 @@
 //@flow
 // eslint-disable-next-line no-unused-vars
-import {Fragment, Component} from 'preact';
+import {Component} from 'preact';
 import styles from './segments-wrapper.scss';
 // eslint-disable-next-line no-unused-vars
 import {SeekBarSegment} from './seekbar-segment';
@@ -37,29 +37,12 @@ const mapDispatchToProps = (dispatch: any) => {
  */
 @redux.connect(mapStateToProps, mapDispatchToProps)
 class SegmentsWrapper extends Component {
-  _lastSegmentUpdated = false;
-
   /**
    * componentWillMount
    * @returns {void}
    */
   componentWillMount(): void {
     this._maybeAddDummySegment();
-  }
-
-  /**
-   * componentWillUpdate
-   * update the endTime of the last segment to match the duration from the engine
-   * @returns {void}
-   */
-  componentWillUpdate(): void {
-    if (!this._lastSegmentUpdated) {
-      const potentialLastSegment = this.props.segments[this.props.segments.length - 1];
-      if (potentialLastSegment.endTime <= this.props.duration && this.props.duration - potentialLastSegment.endTime < 1) {
-        this.props.updateSegmentEndTime(potentialLastSegment.id, this.props.duration);
-        this._lastSegmentUpdated = true;
-      }
-    }
   }
 
   _maybeAddDummySegment = () => {

--- a/src/timeline.js
+++ b/src/timeline.js
@@ -11,6 +11,8 @@ const {Utils} = core;
 const CSS_VARS_POLYFILL_CDN_URL = 'https://cdn.jsdelivr.net/npm/css-vars-ponyfill';
 let cssVarsPolyfillLibLoaded: ?Promise<*> = null;
 
+const TIMELINE_SERVICE = 'timeline';
+
 /**
  * Timeline class.
  * @classdesc
@@ -34,9 +36,13 @@ class Timeline extends BasePlugin {
   constructor(name: string, player: Player, config: Object) {
     super(name, player, config);
     this.player.registerService(
-      'timeline',
-      new TimelineManager(this.player, this.logger, (event: string, payload: any) => this.dispatchEvent(event, payload))
+      TIMELINE_SERVICE,
+      new TimelineManager(this.player, this.logger, (event: string, payload: any) => this.dispatchEvent(event, payload), this.eventManager)
     );
+  }
+
+  loadMedia() {
+    this.player.getService(TIMELINE_SERVICE).loadMedia();
   }
 
   get ready(): Promise<*> {


### PR DESCRIPTION
### Description of the Changes

**the issue:**
in playlist, when switching between entries that have segments on timeline (chapters), sometimes the `duration` state of the engine isn't getting updated fast enough, with the new correct value of the new entry, before the `segmentsWrapper` is setting the duration to the last segment. Hence, sometimes the duration of the last segment is incorrect and as a result, the calculation of the timeline progress is being affected.

**solution:**
make sure the duration is correct and stable, before adding the kaltura cue points.

Solves [FEC-13424](https://kaltura.atlassian.net/browse/FEC-13424)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[FEC-13424]: https://kaltura.atlassian.net/browse/FEC-13424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ