### PR TITLE
fix(SUP-40702): Video quiz is not showing quePoints

### DIFF
--- a/src/timeline-manager.tsx
+++ b/src/timeline-manager.tsx
@@ -111,7 +111,7 @@ class TimelineManager {
     } else if (!clipTo && seekFrom && duration) {
       duration = duration - seekFrom;
     }
-    return Math.floor(this._state.engine.duration) === duration;
+    return Math.round(this._state.engine.duration) === duration;
   };
 
   private _listenerDuration = () => {


### PR DESCRIPTION
### Description of the Changes

**issue:**
markers are not displayed on the timeline when video duration is higher than X.5.

**solution:**
Round the video duration with Math.round instead of Math.floor cause backend returns the duration also with Math.round so need to be aligned. 

solves [SUP-40702](https://kaltura.atlassian.net/browse/SUP-40702)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[SUP-40702]: https://kaltura.atlassian.net/browse/SUP-40702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ