### PR TITLE
fix(FEC-13628): markers not shown on timeline for clipped video

### DIFF
--- a/src/timeline-manager.tsx
+++ b/src/timeline-manager.tsx
@@ -106,7 +106,7 @@ class TimelineManager {
     // @ts-ignore
     const {clipTo, seekFrom} = this._player.sources;
     let duration = this._player.sources.duration;
-    if (clipTo && seekFrom) {
+    if (clipTo && typeof seekFrom === 'number') {
       duration = clipTo - seekFrom;
     } else if (!clipTo && seekFrom && duration) {
       duration = duration - seekFrom;


### PR DESCRIPTION
### Description of the Changes

- **bugfix**

**the issue:**
sometimes markers/chapters are not shown on timeline.

**root cause:**
when checking if the duration is correct, it is possible that `seekFrom` has value of `0`.
currently, when the value is 0, the logic breaks and the new calculation for duration is not happening. As a result, the duration is never correct and `timelineDurationPromise` is never resolved. This affect rendering cuepoints on timeline.

**solution:**
validate `typeof seekFrom`.

Solves [FEC-13628](https://kaltura.atlassian.net/browse/FEC-13628)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[FEC-13628]: https://kaltura.atlassian.net/browse/FEC-13628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ