### PR TITLE
fix(FEC-13779): Thumbnails display when hovering over timeline is choppy

### DIFF
--- a/src/components/marker/timeline-preview.tsx
+++ b/src/components/marker/timeline-preview.tsx
@@ -41,6 +41,7 @@ interface TimelinePreviewProps {
   virtualTime?: number;
   duration?: number;
   getSeekBarNode: () => Element | null;
+  moveOnHover?: boolean;
 }
 
 const getFramePreviewImgContainerStyle = (thumbnailInfo: ThumbnailInfo | ThumbnailInfo[]) => {
@@ -155,6 +156,10 @@ export class TimelinePreview extends Component<TimelinePreviewProps> {
     }
   }
 
+  shouldComponentUpdate(nextProps: Readonly<TimelinePreviewProps>, nextState: Readonly<{}>, nextContext: any): boolean {
+    return this.props.duration !== nextProps.duration || this.props.virtualTime !== nextProps.virtualTime;
+  }
+
   private _renderHeader(relevantChapter: Chapter | undefined, data: any) {
     const {quizQuestions, hotspots, answerOnAir} = data;
 
@@ -240,7 +245,9 @@ export class TimelinePreview extends Component<TimelinePreviewProps> {
 
   onMouseMove = (e: MouseEvent) => {
     // prevent the preview from moving with the mouse
-    e.stopPropagation();
+    if (!this.props.moveOnHover) {
+      e.stopPropagation();
+    }
   };
 
   private _shouldRenderHeader(relevantChapter: Chapter | undefined): boolean {

--- a/src/timeline-manager.tsx
+++ b/src/timeline-manager.tsx
@@ -145,7 +145,7 @@ class TimelineManager {
       replaceComponent: 'ProgressIndicator',
       get: SegmentsWrapper
     });
-    this._addSeekBarPreview();
+    this._addSeekBarPreview(false);
   }
 
   private _restoreProgressIndicator() {
@@ -162,7 +162,7 @@ class TimelineManager {
     });
   }
 
-  private _addSeekBarPreview = () => {
+  private _addSeekBarPreview = (moveOnHover: boolean = true) => {
     // replace the default seekbar frame preview with timeline preview
     this._player.ui.addComponent({
       label: 'Chapter preview',
@@ -171,6 +171,7 @@ class TimelineManager {
       replaceComponent: 'SeekBarPreview',
       get: () => (
         <TimelinePreview
+          moveOnHover={moveOnHover}
           toggleNavigationPlugin={this._toggleNavigationPlugin}
           seekTo={this._seekTo}
           cuePointsData={[]}


### PR DESCRIPTION
### Description of the Changes

- Prevent timeline preview from using stopPropagation when using a dual screen preview, and keep it only for chapters preview
- Add shouldComponentUpdate for timeline preview, otherwise render is constantly triggered because thumbnailInfo reference changes on every get()

Resolves FEC-13779

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
