### PR TITLE
fix(FEC-14101): Player v7 | Hover on the timeline displays a black dot.

### DIFF
--- a/src/components/marker/timeline-preview.scss
+++ b/src/components/marker/timeline-preview.scss
@@ -8,10 +8,10 @@
   padding-top: 40px;
   z-index: 1;
   &:not(.xs-player) {
-    .header{
+    .header:has(.title) {
       background: rgba(0, 0, 0, 0.6);
       border-radius: $roundness-1;
-      &:hover{
+      &:hover {
         background: rgba(0, 0, 0, 0.7);
       }
     }
@@ -37,7 +37,7 @@
   &::after {
     position: absolute;
     bottom: -14px;
-    content: "";
+    content: '';
     width: 100%;
     height: 14px;
     display: block;
@@ -62,7 +62,7 @@
         display: flex;
         align-items: center;
         div {
-          filter: drop-shadow(0px 0px 2px rgba(0, 0, 0, 0.50));
+          filter: drop-shadow(0px 0px 2px rgba(0, 0, 0, 0.5));
         }
         .title {
           flex-grow: 1;

--- a/src/components/marker/timeline-preview.scss
+++ b/src/components/marker/timeline-preview.scss
@@ -37,7 +37,7 @@
   &::after {
     position: absolute;
     bottom: -14px;
-    content: '';
+    content: "";
     width: 100%;
     height: 14px;
     display: block;
@@ -62,7 +62,7 @@
         display: flex;
         align-items: center;
         div {
-          filter: drop-shadow(0px 0px 2px rgba(0, 0, 0, 0.5));
+          filter: drop-shadow(0px 0px 2px rgba(0, 0, 0, 0.50));
         }
         .title {
           flex-grow: 1;


### PR DESCRIPTION
### Description of the Changes

**Issue:**
Hover on timeline, gray dot is displayed above the thumbnail. 

**Root cause:**
This caused since added background to the header preview element so also in case there is no title (hotspot/quiz/answer) the element have the background.

**Fix:**
Add this style only if title element is exist inside the header element.

Solves [FEC-14101](https://kaltura.atlassian.net/browse/FEC-14101)


Player

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[FEC-14101]: https://kaltura.atlassian.net/browse/FEC-14101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ