### PR TITLE
fix(SUP-45380): [Wells Fargo] Black thumbnail on scrubber

### DIFF
--- a/src/components/marker/timeline-preview.tsx
+++ b/src/components/marker/timeline-preview.tsx
@@ -39,6 +39,7 @@ interface TimelinePreviewProps {
   showNavigationTranslate?: string;
   hideNavigationTranslate?: string;
   relevantChapter?: Chapter;
+  virtualTime?: number;
   duration?: number;
   getSeekBarNode: () => Element | null;
   moveOnHover?: boolean;
@@ -123,6 +124,7 @@ const mapStateToProps = (state: State, {markerStartTime}: TimelinePreviewProps) 
     isExtraSmallPlayer: state.shell.playerSize === PLAYER_SIZE.EXTRA_SMALL,
     hidePreview: state.shell.playerSize === PLAYER_SIZE.TINY,
     relevantChapter,
+    virtualTime: state.seekbar.virtualTime,
     duration: state.engine.duration
   };
 };
@@ -155,7 +157,11 @@ export class TimelinePreview extends Component<TimelinePreviewProps> {
   }
 
   shouldComponentUpdate(nextProps: Readonly<TimelinePreviewProps>, nextState: Readonly<{}>, nextContext: any): boolean {
-    return this.props.duration !== nextProps.duration || this.props.relevantChapter !== nextProps.relevantChapter;
+    return (
+      this.props.duration !== nextProps.duration ||
+      this.props.relevantChapter !== nextProps.relevantChapter ||
+      this.props.virtualTime !== nextProps.virtualTime
+    );
   }
 
   private _renderHeader(relevantChapter: Chapter | undefined, data: any) {


### PR DESCRIPTION
### Description of the Changes

Issue:
When timeline plugin is activated and user hover on the seekbar, only the first thumbnail is shown all the time.

Root cause: 
Component is not rendered when user hover the seekbar since relevantChapter is always undefined 

Fix:
Adding the condition also check virtualTime change

Solves [SUP-45380](https://kaltura.atlassian.net/browse/SUP-45380)

### CheckLists


- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[SUP-45380]: https://kaltura.atlassian.net/browse/SUP-45380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ