### PR TITLE
fix(SUP-45037): [UMICH] Audio Entry Timestamp bug

### DIFF
--- a/src/components/marker/timeline-preview.scss
+++ b/src/components/marker/timeline-preview.scss
@@ -53,7 +53,7 @@
     margin-bottom: 2px;
     position: absolute;
     top: -10px;
-    &.header_thumbnail {
+    &.header-thumbnail {
       top: 10px;
     }
     .items-wrapper {

--- a/src/components/marker/timeline-preview.scss
+++ b/src/components/marker/timeline-preview.scss
@@ -52,7 +52,10 @@
     text-shadow: 0 0 2px rgba(0, 0, 0, 0.5);
     margin-bottom: 2px;
     position: absolute;
-    top: 10px;
+    top: -10px;
+    &.header_thumbnail {
+      top: 10px;
+    }
     .items-wrapper {
       display: flex;
       flex-direction: row;

--- a/src/components/marker/timeline-preview.tsx
+++ b/src/components/marker/timeline-preview.tsx
@@ -360,7 +360,7 @@ export class TimelinePreview extends Component<TimelinePreviewProps> {
     return <div style={getFramePreviewImgStyle(thumbnailInfo)} />;
   };
 
-  private _getCuePointPreviewHeaderProps = (data: any) => {
+  private _getCuePointPreviewHeaderProps = (data: any, thumbnailInfo: ThumbnailInfo | ThumbnailInfo[]) => {
     const {quizQuestions, hotspots, answerOnAir} = data;
 
     let ariaLabel = '';
@@ -368,8 +368,13 @@ export class TimelinePreview extends Component<TimelinePreviewProps> {
       ariaLabel = this.props.hotspotTitleAriaLabelTranslate!;
     }
 
+    let className = styles.header
+    if(thumbnailInfo) {
+      className = styles.header + " " + styles.header_thumbnail
+    }
+
     const cuePointPreviewHeaderProps = {
-      className: styles.header,
+      className: className,
       'data-testid': 'cuePointPreviewHeader',
       style: this._getPreviewHeaderStyle(),
       tabIndex: 0,
@@ -399,7 +404,7 @@ export class TimelinePreview extends Component<TimelinePreviewProps> {
         onMouseLeave={() => this.onMouseLeave(relevantChapter)}>
         {this._shouldRenderHeader(relevantChapter) ? (
           <A11yWrapper onClick={this.onPreviewHeaderClick}>
-            <div {...this._getCuePointPreviewHeaderProps(data)} ref={node => (this._previewHeaderElement = node)}>
+            <div {...this._getCuePointPreviewHeaderProps(data, thumbnailInfo)} ref={node => (this._previewHeaderElement = node)}>
               <div className={styles.itemsWrapper} data-testid="cuePointPreviewHeaderItems">
                 {this._renderHeader(relevantChapter, data)}
               </div>

--- a/src/components/marker/timeline-preview.tsx
+++ b/src/components/marker/timeline-preview.tsx
@@ -368,13 +368,13 @@ export class TimelinePreview extends Component<TimelinePreviewProps> {
       ariaLabel = this.props.hotspotTitleAriaLabelTranslate!;
     }
 
-    let className = styles.header
+    const className = [styles.header];
     if(thumbnailInfo) {
-      className = styles.header + " " + styles.header_thumbnail
+      className.push(styles.headerThumbnail);
     }
 
     const cuePointPreviewHeaderProps = {
-      className: className,
+      className: className.join(" "),
       'data-testid': 'cuePointPreviewHeader',
       style: this._getPreviewHeaderStyle(),
       tabIndex: 0,


### PR DESCRIPTION
issue:
when create audio entry with chapters, the chapters on the timeline and the time are on the same line

solution:
add case when there are thumbnails to fit the chapters css if there are thumbnail and if not.

solve [SUP-45037](https://kaltura.atlassian.net/browse/SUP-45037)


[SUP-45037]: https://kaltura.atlassian.net/browse/SUP-45037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ