### PR TITLE
fix(FEC-14300): gaps in the timeline progress

### DIFF
--- a/src/timeline-manager.tsx
+++ b/src/timeline-manager.tsx
@@ -74,6 +74,7 @@ class TimelineManager {
         this._getThumbnailInfoFn = fn;
       },
       addSeekBarPreview: this._addSeekBarPreview,
+      reset: () => this.reset(),
       // Expose entire timelineManager for testing purposes
       ...((window as any)._TEST_ENV ? {timelineManager: this} : {})
     };


### PR DESCRIPTION
### Description of the Changes

**bugfix - regression.**

**the issue:**
when loading a video with chapters, there are gaps in the progress of the timeline.

**root cause:**
since changes in [CR-152](https://github.com/kaltura/playkit-js-timeline/pull/47)- the timeline manager is not registered as a service anymore, so `reset()` is not being invoked when changing media. As a result, when switching media there are duplicated chapters (and timeline segments).

**solution:**
add `reset()` to `timelineManagerAPI` service.

Solves FEC-14300

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[CR-152]: https://kaltura.atlassian.net/browse/CR-152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ