### PR TITLE
fix(FEC-14362): add disableChapters api

### DIFF
--- a/src/timeline-manager.tsx
+++ b/src/timeline-manager.tsx
@@ -39,6 +39,7 @@ class TimelineManager {
   _resolveTimelineDurationPromise = () => {};
   _timelineDurationPromise: Promise<void>;
   _getThumbnailInfoFn: (virtualTime: number) => ThumbnailInfo | Array<ThumbnailInfo>;
+  _shouldIncludeChapters: boolean;
 
   /**
    * @constructor
@@ -52,6 +53,7 @@ class TimelineManager {
     this._cuePointsMap = new Map();
     this._timelineDurationPromise = this._makeTimelineDurationPromise();
     this._getThumbnailInfoFn = this._player.getThumbnail.bind(this._player);
+    this._shouldIncludeChapters = true;
   }
 
   get _uiManager() {
@@ -59,6 +61,12 @@ class TimelineManager {
   }
   get _state(): any {
     return this._store.getState();
+  }
+
+  public disableChapters() {
+    this._shouldIncludeChapters = false;
+    // if there are chapters, reset the array
+    this._chapters = [];
   }
 
   public get timelineManagerAPI() {
@@ -75,6 +83,7 @@ class TimelineManager {
       },
       addSeekBarPreview: this._addSeekBarPreview,
       reset: () => this.reset(),
+      disableChapters: () => this.disableChapters(),
       // Expose entire timelineManager for testing purposes
       ...((window as any)._TEST_ENV ? {timelineManager: this} : {})
     };
@@ -201,12 +210,16 @@ class TimelineManager {
     title?: string,
     cuePointData?: QuizQuestionData | NavigationChapterData | any
   ) => {
-    if (this._state.shell.playerSize === PLAYER_SIZE.TINY || this._uiManager.store.getState().seekbar.isPreventSeek) {
+    if (
+      this._state.shell.playerSize === PLAYER_SIZE.TINY ||
+      this._uiManager.store.getState().seekbar.isPreventSeek ||
+      (type === ItemTypes.Chapter && !this._shouldIncludeChapters)
+    ) {
       return;
     }
     // wait for the duration to be correct and stable
     this._timelineDurationPromise.then(() => {
-      if (type === ItemTypes.Chapter) {
+      if (type === ItemTypes.Chapter || type === ItemTypes.SummaryAndChapters) {
         const chapter: Chapter = {
           type: ItemTypes.Chapter,
           id: cuePointId,
@@ -439,6 +452,7 @@ class TimelineManager {
       this._store.dispatch(actions.updateSeekbarSegments([]));
       this._chapters = [];
     }
+    this._shouldIncludeChapters = true;
   };
 
   private _getThumbnailInfo(virtualTime: number): ThumbnailInfo | Array<ThumbnailInfo> {

--- a/src/timeline-manager.tsx
+++ b/src/timeline-manager.tsx
@@ -131,8 +131,12 @@ class TimelineManager {
     // @ts-ignore
     const {clipTo, seekFrom} = this._player.sources;
     let duration = this._player.sources.duration;
-    if (clipTo && typeof seekFrom === 'number') {
-      duration = clipTo - seekFrom;
+    if (clipTo) {
+      if (typeof seekFrom === 'number' && seekFrom > 0) {
+        duration = clipTo - seekFrom;
+      } else {
+        duration = clipTo;
+      }
     } else if (!clipTo && seekFrom && duration) {
       duration = duration - seekFrom;
     }

--- a/src/types/timelineTypes.ts
+++ b/src/types/timelineTypes.ts
@@ -54,5 +54,6 @@ export enum ItemTypes {
   AnswerOnAir = 'AnswerOnAir',
   Chapter = 'Chapter',
   Hotspot = 'Hotspot',
-  QuizQuestion = 'QuizQuestion'
+  QuizQuestion = 'QuizQuestion',
+  SummaryAndChapters = 'SummaryAndChapters',
 }


### PR DESCRIPTION
### Description of the Changes

**the issue:**
when playkit-unisphere plugin loads summary & chapters widget, but the chapters data is empty, "regular" chapters are not shown on timeline (if exist).

**solution:**
- hold a new flag which indicates whether the timeline manager should or shouldn't add "regular" chapters to the timeline
- add a new API- `disableChapters`, which sets the value of the new flag and resets the chapters array in case that "regular" chapters were loaded already
- expose the api on `timelineManagerAPI`
- distinguish between a "regular" chapter and a summary chapter
- in `addKalturaCuePoint` api, if the incoming cuepoint is "Chapter" and the new flag indicates to not load chapters- then do not add it to the timeline

**additional fix:**
there's a missing use-case in `isDurationCorrect` logic, where only `clipTo` is configured (without `seekFrom`); it causes the `_timelineDurationPromise` to never be resolved; hence, the (regular) chapters are not added to the timeline in this case.

**Note:** "regular chapters" are chapters that are not related or coming from Summary feature.

Resolves FEC-14362

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
