### PR TITLE
fix(FEC-14402): timeline display both regular and summary chapters

### DIFF
--- a/src/timeline-manager.tsx
+++ b/src/timeline-manager.tsx
@@ -214,15 +214,15 @@ class TimelineManager {
     title?: string,
     cuePointData?: QuizQuestionData | NavigationChapterData | any
   ) => {
-    if (
-      this._state.shell.playerSize === PLAYER_SIZE.TINY ||
-      this._uiManager.store.getState().seekbar.isPreventSeek ||
-      (type === ItemTypes.Chapter && !this._shouldIncludeChapters)
-    ) {
+    if (this._state.shell.playerSize === PLAYER_SIZE.TINY || this._uiManager.store.getState().seekbar.isPreventSeek) {
       return;
     }
     // wait for the duration to be correct and stable
     this._timelineDurationPromise.then(() => {
+      if (type === ItemTypes.Chapter && !this._shouldIncludeChapters) {
+        // do not add chapters cuePoints
+        return;
+      }
       if (type === ItemTypes.Chapter || type === ItemTypes.SummaryAndChapters) {
         const chapter: Chapter = {
           type: ItemTypes.Chapter,


### PR DESCRIPTION
### Description of the Changes

bug fix.

**the root cause:**
checking the flag `_shouldIncludeChapters` before the duration promise is resolved; if a chapter comes when `_shouldIncludeChapters` is `true` (before chapters were disabled), then it moves on to await for the duration promise. once the promise is resolved- it adds the chapter even though the chapters were disabled.

**the solution:**
check the `_shouldIncludeChapters` flag after duration promise is resolved.

Resolves FEC-14402

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
