### PR TITLE
feat(FEC-14385): add youtube clip chapter type

### DIFF
--- a/src/types/timelineTypes.ts
+++ b/src/types/timelineTypes.ts
@@ -56,4 +56,5 @@ export enum ItemTypes {
   Hotspot = 'Hotspot',
   QuizQuestion = 'QuizQuestion',
   SummaryAndChapters = 'SummaryAndChapters',
+  YouTubeClipChapter = 'YouTubeClipChapter',
 }


### PR DESCRIPTION
### Description of the Changes

timeline side of the feature:
- add `YouTubeClipChapter` item type
- fix `_isDurationCorrect` logic for youtube & seekFrom/clipTo configuration; the youtube video is not actually clipped (the duration doesn't change), this is causing the duration promise to never be resolved.

Resolves FEC-14385

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
