### PR TITLE
Fix(ADA-2704) - Add title to Hotspot button

### DIFF
--- a/src/components/marker/timeline-preview.tsx
+++ b/src/components/marker/timeline-preview.tsx
@@ -12,16 +12,28 @@ const {
   components: {PLAYER_SIZE}
 } = KalturaPlayer.ui;
 
-const translates = {
-  questionTranslate: <Text id="timeline.question_title">Question</Text>,
-  reflectionPointTranslate: <Text id="timeline.reflection_point_title">Reflection Point</Text>,
-  hotspotTranslate: <Text id="timeline.hotspot_title">Hotspot</Text>,
-  hotspotTitleAriaLabelTranslate: <Text id="timeline.hotspot_title_aria_label">Click to jump to hotspot video position</Text>,
-  aoaTranslate: <Text id="timeline.audience_asked_title">Audience Asked</Text>,
-  showNavigationTranslate: <Text id="navigation.show_plugin">Show Navigation</Text>,
-  hideNavigationTranslate: <Text id="navigation.hide_plugin">Hide Navigation</Text>
-};
+const translates = ({cuePointsData}: TimelinePreviewProps) => {
+  const hotspot = cuePointsData?.find(cp => cp.type === ItemTypes.Hotspot);
+  const hotspotTitle = hotspot?.title;
 
+  return {
+    hotspotTitleAriaLabelTranslate: hotspotTitle ? (
+      <Text id="timeline.hotspot_aria_label" fields={{ title: hotspotTitle }}>
+        {`Click to jump to ${hotspotTitle} hotspot`}
+      </Text>
+    ) : (
+      <Text id="timeline.hotspot_title_aria_label">
+        Click to jump to hotspot video position
+      </Text>
+    ),
+    questionTranslate: <Text id="timeline.question_title">Question</Text>,
+    reflectionPointTranslate: <Text id="timeline.reflection_point_title">Reflection Point</Text>,
+    hotspotTranslate: <Text id="timeline.hotspot_title">Hotspot</Text>,
+    aoaTranslate: <Text id="timeline.audience_asked_title">Audience Asked</Text>,
+    showNavigationTranslate: <Text id="navigation.show_plugin">Show Navigation</Text>,
+    hideNavigationTranslate: <Text id="navigation.hide_plugin">Hide Navigation</Text>
+  };
+};
 interface TimelinePreviewProps {
   onPreviewClick: (e: OnClickEvent, byKeyboard: boolean, chapter: Chapter) => void;
   seekTo: () => void;

--- a/translations/en.i18n.json
+++ b/translations/en.i18n.json
@@ -3,6 +3,7 @@
     "timeline": {
       "hotspot_title": "Hotspot",
       "hotspot_title_aria_label": "Click to jump to hotspot video position",
+      "hotspot_aria_label": "Click to jump to {{title}} hotspot",
       "question_title": "Question",
       "reflection_point_title": "Reflection Point",
       "audience_asked_title": "Audience Asked",


### PR DESCRIPTION
This solves this https://kaltura.atlassian.net/browse/ADA-2704. The hotspot title is announced in the button's aria-label. 
It is related to https://github.com/kaltura/playkit-js-navigation/pull/391, the title being passed from here.
A ticket for translation will be created after approval

### Description of the Changes

Please add a detailed description of the change, weather it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
