### PR TITLE
fix(SUP-47479): player with bumper prevents display of quiz timestamp on the timeline

### DIFF
--- a/src/timeline-manager.tsx
+++ b/src/timeline-manager.tsx
@@ -74,6 +74,7 @@ class TimelineManager {
         this._getThumbnailInfoFn = fn;
       },
       addSeekBarPreview: this._addSeekBarPreview,
+      removeCueFromTimeline: this.removeCueFromTimeline,
       reset: () => this.reset(),
       // Expose entire timelineManager for testing purposes
       ...((window as any)._TEST_ENV ? {timelineManager: this} : {})
@@ -362,6 +363,25 @@ class TimelineManager {
       this._cuePointsRemoveMap.delete(id);
     }
   };
+
+    /**
+   * @param {{id: string, startTime: number}} cuePoint - An object contains the cue point id and cue point start time
+   * @returns {void}
+   */
+    public removeCueFromTimeline = (cuePoint: {id: string, startTime: number}): void => {
+      const {id, startTime} = cuePoint;
+      const fn = this._cuePointsRemoveMap.get(id);
+  
+      this._cuePointsRemoveMap.forEach((id) => {
+        console.log(id)
+      });
+      if (typeof fn === 'function') {
+        fn();
+        this._cuePointsRemoveMap.delete(id);
+      }
+  
+      this._cuePointsMap.delete(startTime);
+    };
 
   /**
    * @param {SeekbarPreviewOptionsObject} preview - The seekbar preview options

--- a/src/timeline-manager.tsx
+++ b/src/timeline-manager.tsx
@@ -369,12 +369,8 @@ class TimelineManager {
    * @returns {void}
    */
     public removeCueFromTimeline = (cuePoint: {id: string, startTime: number}): void => {
-      const {id, startTime} = cuePoint;
-      const fn = this._cuePointsRemoveMap.get(id);
-      if (typeof fn === 'function') {
-        fn();
-        this._cuePointsRemoveMap.delete(id);
-      }
+      const {id, startTime} = cuePoint
+      this.removeCuePoint({id})
       this._cuePointsMap.delete(startTime);
     };
 

--- a/src/timeline-manager.tsx
+++ b/src/timeline-manager.tsx
@@ -371,15 +371,10 @@ class TimelineManager {
     public removeCueFromTimeline = (cuePoint: {id: string, startTime: number}): void => {
       const {id, startTime} = cuePoint;
       const fn = this._cuePointsRemoveMap.get(id);
-  
-      this._cuePointsRemoveMap.forEach((id) => {
-        console.log(id)
-      });
       if (typeof fn === 'function') {
         fn();
         this._cuePointsRemoveMap.delete(id);
       }
-  
       this._cuePointsMap.delete(startTime);
     };
 


### PR DESCRIPTION
Issue:
The cue-points of the IVQ questions are loaded when the ads are playing, therefore, they are not seen in the seek bar when the entry is playing.

Fix:
When all the ads are completed, remove all the cue-points and put them again, in order to see them on the seekbar.

solved [SUP-47479](https://kaltura.atlassian.net/browse/SUP-47479)

[SUP-47479]: https://kaltura.atlassian.net/browse/SUP-47479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ