### PR TITLE
feat(FEC-14710): Player UI display of EAD on scrubber timeline + real-time updates of cuepoints and scrubber position

### DIFF
--- a/flow-typed/types/cue-point-option.ts
+++ b/flow-typed/types/cue-point-option.ts
@@ -78,5 +78,6 @@ export type Chapter = {
   endTime: number;
   isDummy?: boolean;
   isHovered: boolean;
+  chapterType?: string;
   onPreviewClick: (e: OnClickEvent, byKeyboard: boolean, chapter: Chapter) => void;
 };

--- a/src/components/chapters/seekbar-segment.js
+++ b/src/components/chapters/seekbar-segment.js
@@ -1,11 +1,13 @@
 //@flow
 import * as KalturaPlayer from '@playkit-js/kaltura-player-js';
+import {ItemTypes, TimelineEventTypes} from '../../types/timelineTypes';
 import styles from './seekbar-segment.scss';
 
 const {redux, reducers, preact, components} = KalturaPlayer.ui;
 const {Component} = preact;
 const {seekbar} = reducers;
 const {withPlayer} = components;
+const {FakeEvent} = KalturaPlayer.core;
 
 /**
  * mapping state to props
@@ -53,7 +55,7 @@ class SeekBarSegment extends Component {
    * @private
    */
   _getSegmentWidth(): number {
-    if (this._segmentEl && this.props.duration) {
+    if (this.props.seekbarClientRect && this.props.duration) {
       const seekbarRect = this.props.seekbarClientRect;
       const seekbarWidth = seekbarRect.width;
       const segmentStartTimePosition = (this.props.startTime < this.props.duration ? this.props.startTime / this.props.duration : 1) * seekbarWidth;
@@ -84,6 +86,12 @@ class SeekBarSegment extends Component {
   onMouseOver = (): void => {
     if (this.props.isMobile) return;
     this.props.updateHoveredSegment(this.props.id, true);
+    if (this.props.chapterType === ItemTypes.ADChapter) {
+      const hoveredSegment = this.props.segments.find(segment => segment.id === this.props.id);
+      this.props.player.dispatchEvent(
+        new FakeEvent(TimelineEventTypes.ADChapterHover, {startTime: hoveredSegment.startTime, endTime: hoveredSegment.endTime})
+      );
+    }
   };
 
   /**
@@ -179,6 +187,9 @@ class SeekBarSegment extends Component {
     const segmentStyleClass = [styles.seekBarSegment];
     if (isHovered) {
       segmentStyleClass.push(styles.hovered);
+    }
+    if (props.chapterType === ItemTypes.ADChapter) {
+      segmentStyleClass.push(styles.adSegment);
     }
 
     // Combine styles as a string

--- a/src/components/chapters/seekbar-segment.scss
+++ b/src/components/chapters/seekbar-segment.scss
@@ -32,4 +32,16 @@
     @include base-segment;
     background-color: rgba(255, 255, 255, 0.3);
   }
+
+  &.ad-segment {
+    background-color: rgba(255, 255, 255, 1);
+
+    .buffered {
+      background-color: rgba(255, 255, 255, 0.6);
+    }
+
+    .segment-progress {
+      background-color: rgba(255, 255, 255, 0.6);
+    }
+  }
 }

--- a/src/components/chapters/segments-wrapper.js
+++ b/src/components/chapters/segments-wrapper.js
@@ -80,6 +80,7 @@ class SegmentsWrapper extends Component {
               title={chapter.title}
               isHovered={chapter.isHovered}
               isDummy={chapter.isDummy}
+              chapterType={chapter.chapterType}
               style={styleString} // Pass as string to match the component's expectation
               segments={props.segments} // Pass all segments to each segment component
             />

--- a/src/components/marker/timeline-preview.tsx
+++ b/src/components/marker/timeline-preview.tsx
@@ -57,7 +57,7 @@ interface TimelinePreviewProps {
   moveOnHover?: boolean;
 }
 
-const getFramePreviewImgContainerStyle = (thumbnailInfo: ThumbnailInfo | ThumbnailInfo[]): Record<string, string> => {
+const getFramePreviewImgContainerStyle = (thumbnailInfo?: ThumbnailInfo | ThumbnailInfo[]): Record<string, string> => {
   if (!thumbnailInfo) {
     return {
       borderColor: 'transparent'
@@ -370,14 +370,18 @@ export class TimelinePreview extends Component<TimelinePreviewProps> {
     return style;
   }
 
-  private _renderThumbnail = (thumbnailInfo: ThumbnailInfo | Array<ThumbnailInfo>) => {
+  private _renderThumbnail = (thumbnailInfo?: ThumbnailInfo | Array<ThumbnailInfo>) => {
+    if (!thumbnailInfo) {
+      return;
+    }
+
     if (Array.isArray(thumbnailInfo)) {
       return thumbnailInfo.map(info => <div style={getFramePreviewImgStyle(info)} />);
     }
     return <div style={getFramePreviewImgStyle(thumbnailInfo)} />;
   };
 
-  private _getCuePointPreviewHeaderProps = (data: any, thumbnailInfo: ThumbnailInfo | ThumbnailInfo[]) => {
+  private _getCuePointPreviewHeaderProps = (data: any, thumbnailInfo?: ThumbnailInfo | ThumbnailInfo[]) => {
     const {quizQuestions, hotspots, answerOnAir} = data;
 
     let ariaLabel = '';
@@ -409,7 +413,12 @@ export class TimelinePreview extends Component<TimelinePreviewProps> {
 
     const {getThumbnailInfo, isExtraSmallPlayer, relevantChapter} = this.props;
     const data = this._getData();
-    const thumbnailInfo = getThumbnailInfo();
+
+    const isAdChapterSegment = relevantChapter?.chapterType === ItemTypes.ADChapter || relevantChapter?.id === 'empty-segment';
+    let thumbnailInfo: ThumbnailInfo | ThumbnailInfo[] | undefined;
+    if (!isAdChapterSegment) {
+      thumbnailInfo = getThumbnailInfo();
+    }
     const className = [styles.container, this.props.isExtraSmallPlayer ? styles.xsPlayer : ''].join(' ');
 
     return (

--- a/src/timeline-manager.tsx
+++ b/src/timeline-manager.tsx
@@ -55,7 +55,7 @@ class TimelineManager {
     this._timelineDurationPromise = this._makeTimelineDurationPromise();
     this._getThumbnailInfoFn = this._player.getThumbnail.bind(this._player);
     this._shouldIncludeChapters = true;
-    this._chapterTypesArray = [ItemTypes.Chapter, ItemTypes.SummaryAndChapters, ItemTypes.YouTubeClipChapter];
+    this._chapterTypesArray = [ItemTypes.Chapter, ItemTypes.SummaryAndChapters, ItemTypes.YouTubeClipChapter, ItemTypes.ADChapter];
   }
 
   get _uiManager() {
@@ -86,6 +86,7 @@ class TimelineManager {
       addSeekBarPreview: this._addSeekBarPreview,
       removeCueFromTimeline: this.removeCueFromTimeline,
       reset: () => this.reset(),
+      resetChapters: () => this.resetChapters(),
       disableChapters: () => this.disableChapters(),
       // Expose entire timelineManager for testing purposes
       ...((window as any)._TEST_ENV ? {timelineManager: this} : {})
@@ -106,12 +107,38 @@ class TimelineManager {
     this._player.currentTime = this._state.seekbar.virtualTime;
   };
 
-  private _handleChapter = (chapter: Chapter) => {
-    if (this._chapters.length > 0) {
-      // set the previous chapter's endTime to be the current chapter's startTime
-      this._chapters[this._chapters.length - 1].endTime = chapter.startTime;
+  private _handleADChapter = (chapter: Chapter) => {
+    if (this._chapters.length !== 0) {
+      const lastChapter = this._chapters[this._chapters.length - 1];
+      const gap = chapter.startTime - lastChapter.endTime;
+
+      if (gap > 0) {
+        const emptySegment: Chapter = {
+          id: 'empty-segment',
+          type: ItemTypes.Chapter,
+          title: '',
+          startTime: lastChapter.endTime,
+          endTime: chapter.startTime,
+          isDummy: true,
+          isHovered: false,
+          onPreviewClick: () => {}
+        };
+        this._chapters.push(emptySegment);
+      }
     }
     this._chapters.push(chapter);
+  };
+
+  private _handleChapter = (chapter: Chapter) => {
+    if (chapter.chapterType === ItemTypes.ADChapter) {
+      this._handleADChapter(chapter);
+    } else {
+      if (this._chapters.length > 0) {
+        // set the previous chapter's endTime to be the current chapter's startTime
+        this._chapters[this._chapters.length - 1].endTime = chapter.startTime;
+      }
+      this._chapters.push(chapter);
+    }
 
     // add segement to seekbar
     const progressBarEl = this._getProgressBarEl();
@@ -228,14 +255,16 @@ class TimelineManager {
         return;
       }
       if (this._chapterTypesArray.includes(type)) {
+        const endTime = cuePointData?.endTime || this._state.engine.duration;
         const chapter: Chapter = {
           type: ItemTypes.Chapter,
           id: cuePointId,
           startTime: startTime,
           title: title!,
-          endTime: this._state.engine.duration,
+          endTime: endTime,
           isHovered: false,
           isDummy: false,
+          chapterType: type,
           onPreviewClick: (e: OnClickEvent, byKeyboard: boolean, relevantChapter: Chapter) => {
             cuePointData?.onClick?.({e, byKeyboard, cuePoint: relevantChapter});
           }
@@ -458,6 +487,13 @@ class TimelineManager {
     this.reset();
   }
 
+  
+  resetChapters = ()=> {
+    if (this._chapters.length) {
+      this._store.dispatch(actions.updateSeekbarSegments([]));
+      this._chapters = [];
+    }
+  }
   private _removeAllCuePoints = () => {
     this._cuePointsRemoveMap.forEach((fn, key) => {
       this.removeCuePoint({id: key});
@@ -466,10 +502,7 @@ class TimelineManager {
 
     this._restoreProgressIndicator();
     this._restoreSeekBarPreview();
-    if (this._chapters.length) {
-      this._store.dispatch(actions.updateSeekbarSegments([]));
-      this._chapters = [];
-    }
+    this.resetChapters()
     this._shouldIncludeChapters = true;
   };
 

--- a/src/types/timelineTypes.ts
+++ b/src/types/timelineTypes.ts
@@ -57,4 +57,9 @@ export enum ItemTypes {
   QuizQuestion = 'QuizQuestion',
   SummaryAndChapters = 'SummaryAndChapters',
   YouTubeClipChapter = 'YouTubeClipChapter',
+  ADChapter = 'ADChapter',
+}
+
+export enum TimelineEventTypes {
+  ADChapterHover = 'ADChapterHover',
 }


### PR DESCRIPTION
### Description of the Changes

Adding the ability to display the EAD caption lines as a chapters on the timeline.
The timeline will be updated when caption is added or removed in the editor.
The AD chapters color is white even in progress (will be white instead of primary color)
When hovering on AD segment a new event will be dispatched with startTime and endTime of the cuepoint.
When AD segments is displayed on the timeline, there is no thumbnails and titles when hovering on the seekbar.

solves [FEC-14710](https://kaltura.atlassian.net/browse/FEC-14710) [FEC-14891](https://kaltura.atlassian.net/browse/FEC-14891)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[FEC-14710]: https://kaltura.atlassian.net/browse/FEC-14710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FEC-14891]: https://kaltura.atlassian.net/browse/FEC-14891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ